### PR TITLE
Add IE<9 fallback for event.preventDefault

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,12 @@ function init(element, opts) {
   thumbnailClass.add('lazyYT-image-loaded');
 
   on(thumbnail, 'click', function (event) {
-    event.preventDefault();
+    if (event.preventDefault) {
+      event.preventDefault();
+    } else {
+      event.returnValue = false;
+    }
+    
     if (thumbnail.className && thumbnailClass.has('lazyYT-image-loaded') &&
         !elementClass(element).has('lazyYT-video-loaded')) {
       elementClass(element).add('lazyYT-video-loaded');


### PR DESCRIPTION
IE8 doesn't support `event.preventDefault`, but setting `event.returnValue` to `false` has the same effect.
